### PR TITLE
update default registry hives

### DIFF
--- a/actions/test/regCheck3.json
+++ b/actions/test/regCheck3.json
@@ -1,0 +1,36 @@
+{
+    "name": "Extract and Search windows registry",
+    "description": {
+        "author": "Mike",
+        "email": "blackstar138@gmail.com",
+        "revision": 201409031800
+    },
+    "target": "agents.environment->>'os' = 'windows'",
+    "threat": {
+        "level": "-",
+        "family": "test"
+    },
+    "operations": [{
+        "module": "registry",
+        "parameters": {
+            "rekall": {
+                "plugin": "hives",
+                "pluginoptions": [""],
+                "checkvalues": false,
+                "dumpdirectory": "",
+            },
+            "regrip": {
+                "regdirectory": "",
+                "reportdirectory": "",
+                "plugins": [""]
+            },
+            "search": {
+                "searchkeys": ["VBoxTray.exe", "Aliases/Names/WinRMRemoteWMIUsers"],
+                "searchvalues": [""],
+                "searchdata": [""],
+                "checkdaterange": false
+            }
+        }
+    }],
+    "syntaxversion": 2
+}


### PR DESCRIPTION
Users can select registry hives in input parameter, but currently
default hives are set to [SAM, SECURITY, SOFTWARE, SYSTEM, NTUSER.dat].

Now we want to update the default setting to cycle through all hives
found by Rekall
